### PR TITLE
chore: Run gc pods and gc activities every half hour

### DIFF
--- a/env/jenkins-x-platform/values.tmpl.yaml
+++ b/env/jenkins-x-platform/values.tmpl.yaml
@@ -131,7 +131,14 @@ gcactivities:
     - "activities"
     - "--batch-mode"
     - "--pr-history-limit=30"
+  cronjob:
+    enabled: true
+    schedule: "0/30 * * * *"
   image:
     repository: gcr.io/jenkinsxio/builder-jx
     tag: 0.1.658
 
+gcpods:
+  cronjob:
+    enabled: true
+    schedule: "0/30 * * * *"


### PR DESCRIPTION
Previously they were running at 0 and 30 past the hour every third
hour, which was...odd.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>