### PR TITLE
fix: Re-disable metapipeline due to json logging breaking tests

### DIFF
--- a/env/prow/values.tmpl.yaml
+++ b/env/prow/values.tmpl.yaml
@@ -11,6 +11,10 @@ user: "{{ .Parameters.pipelineUser.username }}"
 buildnum:
   enabled: false
 pipelinerunner:
+  args:
+  - controller
+  - pipelinerunner
+  - --use-meta-pipeline=false
   enabled: "true"
   image:
     repository: gcr.io/jenkinsxio/builder-maven


### PR DESCRIPTION
See https://github.com/jenkins-x/jx/issues/5208

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>