### PR TITLE
fix: Bump version stream cronjob image to 0.1.672

### DIFF
--- a/env/templates/version-stream-update-cj.yaml
+++ b/env/templates/version-stream-update-cj.yaml
@@ -37,7 +37,7 @@ spec:
               value: jenkins-x-bot
             - name: PIPELINE_KIND
               value: release
-            image: gcr.io/jenkinsxio/builder-go:0.1.667
+            image: gcr.io/jenkinsxio/builder-go:0.1.672
             imagePullPolicy: IfNotPresent
             name: jx-version-stream-update
             resources: {}


### PR DESCRIPTION
This picks up the various changes in https://github.com/jenkins-x/jx/pull/5227

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>