### PR TITLE
fix: remove quotes from version stream cronjob args, bump image

### DIFF
--- a/env/templates/version-stream-update-cj.yaml
+++ b/env/templates/version-stream-update-cj.yaml
@@ -22,9 +22,9 @@ spec:
             - create
             - pr
             - versions
-            - --filter=\"*\"
+            - --filter=*
             - --images
-            - --excludes='jetstack/cert-manager'
+            - --excludes=jetstack/cert-manager
             - --batch-mode
             command:
             - jx
@@ -37,7 +37,7 @@ spec:
               value: jenkins-x-bot
             - name: PIPELINE_KIND
               value: release
-            image: gcr.io/jenkinsxio/builder-go:0.1.676
+            image: gcr.io/jenkinsxio/builder-go:0.1.684
             imagePullPolicy: IfNotPresent
             name: jx-version-stream-update
             resources: {}


### PR DESCRIPTION
This will get the cronjob actually functioning again.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>