### PR TITLE
fix: Pick up latest image for e2e gc cronjob

### DIFF
--- a/env/templates/e2e-gc-cj.yaml
+++ b/env/templates/e2e-gc-cj.yaml
@@ -30,7 +30,7 @@ spec:
               value: json
             - name: GKE_SA_KEY_FILE
               value: "/builder/home/bdd-credentials.json"
-            image: gcr.io/jenkinsxio/builder-go:0.1.658
+            image: gcr.io/jenkinsxio/builder-go:0.1.684
             imagePullPolicy: IfNotPresent
             name: e2e-gc
             resources: {}


### PR DESCRIPTION
This'll keep it from deleting `boot-lh` clusters when there's a
`boot-lh-ghe` running, due to (until now) it checking whether another
running cluster _contains_ the first cluster's type.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>