### PR TITLE
fix: Bump version stream cronjob image

### DIFF
--- a/env/templates/version-stream-update-cj.yaml
+++ b/env/templates/version-stream-update-cj.yaml
@@ -37,7 +37,7 @@ spec:
               value: jenkins-x-bot
             - name: PIPELINE_KIND
               value: release
-            image: gcr.io/jenkinsxio/builder-go:0.1.684
+            image: gcr.io/jenkinsxio/builder-go:0.1.697
             imagePullPolicy: IfNotPresent
             name: jx-version-stream-update
             resources: {}


### PR DESCRIPTION
This picks up a couple fixes to `jx step create pr versions`.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>