### PR TITLE
fix: Update gc activities cronjob image

### DIFF
--- a/env/jenkins-x-platform/values.tmpl.yaml
+++ b/env/jenkins-x-platform/values.tmpl.yaml
@@ -156,7 +156,7 @@ gcactivities:
     schedule: "0/30 * * * *"
   image:
     repository: gcr.io/jenkinsxio/builder-jx
-    tag: 0.1.658
+    tag: 0.1.699
 
 gcpods:
   cronjob:


### PR DESCRIPTION
This'll pick up the fix for the parameters being flipped for release
age and PR age, so that we actually delete PRs after two days and keep
releases for 30.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>