### PR TITLE
fix: remove git labels from test secrets

### DIFF
--- a/env/prow/values.tmpl.yaml
+++ b/env/prow/values.tmpl.yaml
@@ -18,7 +18,7 @@ pipelinerunner:
   enabled: "true"
   image:
     repository: gcr.io/jenkinsxio/builder-maven
-    tag: 0.1.672
+    tag: 0.1.723
 tillerNamespace: ""
 
 sinker:

--- a/env/templates/gh-test-secret.yaml
+++ b/env/templates/gh-test-secret.yaml
@@ -14,7 +14,5 @@ metadata:
   labels:
     jenkins.io/created-by: jx
     jenkins.io/credentials-type: usernamePassword
-    jenkins.io/kind: git
-    jenkins.io/service-kind: github
 type: Opaque
 {{- end }}

--- a/env/templates/git-test-bbs-secret.yaml
+++ b/env/templates/git-test-bbs-secret.yaml
@@ -14,7 +14,5 @@ metadata:
   labels:
     jenkins.io/created-by: jx
     jenkins.io/credentials-type: usernamePassword
-    jenkins.io/kind: git
-    jenkins.io/service-kind: bitbucketserver
 type: Opaque
 {{- end }}

--- a/env/templates/git-test-ghe-secret.yaml
+++ b/env/templates/git-test-ghe-secret.yaml
@@ -16,7 +16,5 @@ metadata:
   labels:
     jenkins.io/created-by: jx
     jenkins.io/credentials-type: usernamePassword
-    jenkins.io/kind: git
-    jenkins.io/service-kind: github
 type: Opaque
 {{- end }}

--- a/env/templates/git-test-gitlab-secret.yaml
+++ b/env/templates/git-test-gitlab-secret.yaml
@@ -12,9 +12,6 @@ metadata:
     jenkins.io/test: "true"
     jenkins.io/credentials-description: API Token for acccessing https://gitlab.com Git service for tests
   labels:
-    jenkins.io/created-by: jx
     jenkins.io/credentials-type: usernamePassword
-    jenkins.io/kind: git
-    jenkins.io/service-kind: gitlab
 type: Opaque
 {{- end }}


### PR DESCRIPTION
so we don't load these secrets into the git auth, breaking build controller and possibly other things