### PR TITLE
fix: Update gcactivities image and prow pipeline image

### DIFF
--- a/env/jenkins-x-platform/values.tmpl.yaml
+++ b/env/jenkins-x-platform/values.tmpl.yaml
@@ -156,7 +156,7 @@ gcactivities:
     schedule: "0/30 * * * *"
   image:
     repository: gcr.io/jenkinsxio/builder-jx
-    tag: 0.1.699
+    tag: 0.1.723
 
 gcpods:
   cronjob:

--- a/env/prow/values.tmpl.yaml
+++ b/env/prow/values.tmpl.yaml
@@ -23,9 +23,3 @@ tillerNamespace: ""
 
 sinker:
   replicaCount: 0
-
-pipeline:
-  image:
-    repository: gcr.io/jenkinsxio/prow/pipeline
-    tag: v20190826-3976f61
-


### PR DESCRIPTION
This will get `PipelineRun`s properly GCed now that they're
disconnected from `PipelineActivity`s, and sync the `pipeline` prow
image with the rest of Prow, now that there's a Prow release with the
relevant fixes from Pete's image in it. That'll also pick up the
theoretical fix for the `pipeline not found` error, though I can't be
100% sure that'll work correctly, so I'll be monitoring things...intensely.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>