### PR TITLE
fix: Use newer pipeline image from prow for the moment

### DIFF
--- a/env/prow/values.tmpl.yaml
+++ b/env/prow/values.tmpl.yaml
@@ -23,3 +23,8 @@ tillerNamespace: ""
 
 sinker:
   replicaCount: 0
+
+pipeline:
+  image:
+    repository: gcr.io/jenkinsxio/prow/pipeline
+    tag: v20190906-f446bfc


### PR DESCRIPTION
This'll end up in the version stream tonight, but the current state of
the auto-retry on `pipeline not found` is...not good, so let's bump
the image for the moment.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>