### PR TITLE
fix: Switch a few images to use version stream instead of explicit

### DIFF
--- a/env/jenkins-x-platform/values.tmpl.yaml
+++ b/env/jenkins-x-platform/values.tmpl.yaml
@@ -154,9 +154,6 @@ gcactivities:
   cronjob:
     enabled: true
     schedule: "0/30 * * * *"
-  image:
-    repository: gcr.io/jenkinsxio/builder-jx
-    tag: 0.1.723
 
 gcpods:
   cronjob:

--- a/env/prow/values.tmpl.yaml
+++ b/env/prow/values.tmpl.yaml
@@ -16,15 +16,8 @@ pipelinerunner:
   - pipelinerunner
   - --use-meta-pipeline=false
   enabled: "true"
-  image:
-    repository: gcr.io/jenkinsxio/builder-maven
-    tag: 0.1.723
 tillerNamespace: ""
 
 sinker:
   replicaCount: 0
 
-pipeline:
-  image:
-    repository: gcr.io/jenkinsxio/prow/pipeline
-    tag: v20190906-f446bfc

--- a/env/templates/copy-charts-index-cj.yaml
+++ b/env/templates/copy-charts-index-cj.yaml
@@ -15,7 +15,7 @@ spec:
           - name: prepare-chart-index
             # curl the index.yaml file from chartmuseum before attempting a copy. This causes it to regenerate.
             # No need to wait afterwards as the http call won't return until it's ready
-            image: gcr.io/jenkinsxio/builder-go:0.1.658
+            image: gcr.io/jenkinsxio/builder-go:0.1.754
             imagePullPolicy: IfNotPresent
             env:
               - name: URL

--- a/env/templates/e2e-gc-cj.yaml
+++ b/env/templates/e2e-gc-cj.yaml
@@ -30,7 +30,7 @@ spec:
               value: json
             - name: GKE_SA_KEY_FILE
               value: "/builder/home/bdd-credentials.json"
-            image: gcr.io/jenkinsxio/builder-go:0.1.684
+            image: gcr.io/jenkinsxio/builder-go:0.1.754
             imagePullPolicy: IfNotPresent
             name: e2e-gc
             resources: {}

--- a/env/templates/version-stream-update-cj.yaml
+++ b/env/templates/version-stream-update-cj.yaml
@@ -37,7 +37,7 @@ spec:
               value: jenkins-x-bot
             - name: PIPELINE_KIND
               value: release
-            image: gcr.io/jenkinsxio/builder-go:0.1.697
+            image: gcr.io/jenkinsxio/builder-go:0.1.754
             imagePullPolicy: IfNotPresent
             name: jx-version-stream-update
             resources: {}


### PR DESCRIPTION
There's no need to use custom tags on these any more. This doesn't turn on metapipeline or anything, mind you.

Also updated cronjob images to use the most recent. I left the `jenkins-x.yml` tags as they are because, well, didn't see a need to change them. =)

Holding until https://github.com/jenkins-x/jenkins-x-versions/pull/493 is merged

/hold