### PR TITLE
feat: add replace:true to presubmits to avoid having the default scheduler context for ci builds

### DIFF
--- a/env/templates/ci-scheduler.yaml
+++ b/env/templates/ci-scheduler.yaml
@@ -28,6 +28,7 @@ spec:
   policy:
     protectTested: true
   presubmits:
+    replace: true
     entries:
     - agent: tekton
       alwaysRun: true


### PR DESCRIPTION
We only want the `ci` context for the frontend.