### PR TITLE
chore: Add boot-vault context to jx

### DIFF
--- a/env/templates/jx-scheduler.yaml
+++ b/env/templates/jx-scheduler.yaml
@@ -129,3 +129,23 @@ spec:
       report: true
       rerunCommand: /build images
       trigger: (?m)^/build images,?(\s+|$)
+    - agent: tekton
+      alwaysRun: false
+      context: boot-vault
+      name: boot-vault
+      queries:
+        - labels:
+            entries:
+              - approved
+              - lgtm
+          missingLabels:
+            entries:
+              - do-not-merge
+              - do-not-merge/hold
+              - do-not-merge/work-in-progress
+              - needs-ok-to-test
+              - needs-rebase
+              - needs-security-review
+      report: true
+      rerunCommand: /test boot-vault
+      trigger: (?m)^/test( all| boot| boot-vault),?(\s+|$)


### PR DESCRIPTION
For the moment, this isn't going to be run by default and isn't a
required context, until we have it working correctly on https://github.com/jenkins-x/jx/pull/5607

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>