### PR TITLE
fix: Use consistent source repo name for jenkins-x-github-app

### DIFF
--- a/repositories/templates/cloudbees.yaml
+++ b/repositories/templates/cloudbees.yaml
@@ -118,7 +118,7 @@ metadata:
     owner: cloudbees
     provider: github
     repository: jenkins-x-github-app
-  name: cloudbees-jx-github-app
+  name: cloudbees-jenkins-x-github-app
   namespace: jx
 spec:
   description: Imported application for cloudbees/jenkins-x-github-app


### PR DESCRIPTION
Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>