### PR TITLE
chore: Make boot-vault context required on jx PRs

### DIFF
--- a/env/templates/jx-scheduler.yaml
+++ b/env/templates/jx-scheduler.yaml
@@ -34,6 +34,7 @@ spec:
             - tekton
             - bdd
             - lint
+            - boot-vault
       queries:
       - labels:
           entries:
@@ -130,7 +131,7 @@ spec:
       rerunCommand: /build images
       trigger: (?m)^/build images,?(\s+|$)
     - agent: tekton
-      alwaysRun: false
+      alwaysRun: true
       context: boot-vault
       name: boot-vault
       queries:


### PR DESCRIPTION
Holding until https://github.com/jenkins-x/jx/pull/5607 (or more likely a PR from @rawlingsj) has merged.