### PR TITLE
fix: Use temporary image for controllerbuild

### DIFF
--- a/env/jenkins-x-platform/values.tmpl.yaml
+++ b/env/jenkins-x-platform/values.tmpl.yaml
@@ -143,6 +143,13 @@ controllerbuild:
   - "--batch-mode"
   - "--git-credentials"
   - "--verbose"
+{{- else }}
+# Remove this else once https://github.com/jenkins-x/jx/pull/5651 is merged/released/in version stream
+controllerbuild:
+  enabled: true
+  image:
+    repository: gcr.io/jenkinsxio/builder-go
+    tag: 0.0.0-SNAPSHOT-PR-5651-18
 {{- end }}
 
 gcactivities:


### PR DESCRIPTION
Will remove this once https://github.com/jenkins-x/jx/pull/5651 is
merged/released/in version stream, but this unbreaks `controllerbuild`
LTS log archiving for the moment.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>