### PR TITLE
fix: Stop using PR-5651 image for controllerbuild

### DIFF
--- a/env/jenkins-x-platform/values.tmpl.yaml
+++ b/env/jenkins-x-platform/values.tmpl.yaml
@@ -143,13 +143,6 @@ controllerbuild:
   - "--batch-mode"
   - "--git-credentials"
   - "--verbose"
-{{- else }}
-# Remove this else once https://github.com/jenkins-x/jx/pull/5651 is merged/released/in version stream
-controllerbuild:
-  enabled: true
-  image:
-    repository: gcr.io/jenkinsxio/builder-go
-    tag: 0.0.0-SNAPSHOT-PR-5651-18
 {{- end }}
 
 gcactivities:


### PR DESCRIPTION
This reverts commit 7a370f0a34a5b9e51566d13934a6f0980d0e2eff.

No longer needed - it's in the version stream now.

/assign @ccojocar 