### PR TITLE
chore: Enabled updatebot automerging of jenkins-x-versions PRs

### DIFF
--- a/env/templates/jx-versions-scheduler.yaml
+++ b/env/templates/jx-versions-scheduler.yaml
@@ -45,6 +45,17 @@ spec:
           - needs-ok-to-test
           - needs-rebase
           - needs-security-review
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test static
       trigger: (?m)^/test( all| static),?(s+|$)
@@ -65,6 +76,17 @@ spec:
           - needs-ok-to-test
           - needs-rebase
           - needs-security-review
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test tiller
       trigger: (?m)^/test( tiller),?(s+|$)
@@ -85,6 +107,17 @@ spec:
           - needs-ok-to-test
           - needs-rebase
           - needs-security-review
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test gitops
       trigger: (?m)^/test( gitops),?(s+|$)
@@ -105,6 +138,17 @@ spec:
           - needs-ok-to-test
           - needs-rebase
           - needs-security-review
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test tekton
       trigger: (?m)^/test( all| tekton),?(s+|$)
@@ -125,6 +169,17 @@ spec:
           - needs-ok-to-test
           - needs-rebase
           - needs-security-review
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test ekstekton
       trigger: (?m)^/test( ekstekton),?(s+|$)
@@ -145,6 +200,17 @@ spec:
           - needs-ok-to-test
           - needs-rebase
           - needs-security-review
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test eksclassic
       trigger: (?m)^/test( eksclassic),?(s+|$)
@@ -165,6 +231,17 @@ spec:
           - needs-ok-to-test
           - needs-rebase
           - needs-security-review
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test ng
       trigger: (?m)^/test( ng),?(s+|$)
@@ -184,6 +261,17 @@ spec:
           - do-not-merge/work-in-progress
           - needs-ok-to-test
           - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test static-gke-us-east1-b
       trigger: (?m)^/test( static-gke-us-east1-b),?(s+|$)
@@ -203,6 +291,17 @@ spec:
           - do-not-merge/work-in-progress
           - needs-ok-to-test
           - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test helm3
       trigger: (?m)^/test( helm3),?(s+|$)
@@ -222,6 +321,17 @@ spec:
           - do-not-merge/work-in-progress
           - needs-ok-to-test
           - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test terraform-static
       trigger: (?m)^/test( terraform-static),?(s+|$)
@@ -241,6 +351,17 @@ spec:
           - do-not-merge/work-in-progress
           - needs-ok-to-test
           - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test terraform-tekton
       trigger: (?m)^/test( terraform-tekton),?(s+|$)
@@ -260,6 +381,17 @@ spec:
           - do-not-merge/work-in-progress
           - needs-ok-to-test
           - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test boot-local
       trigger: (?m)^/test( all| boot| boot-local),?(s+|$)
@@ -279,6 +411,17 @@ spec:
           - do-not-merge/work-in-progress
           - needs-ok-to-test
           - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test boot-jenkins
       trigger: (?m)^/test( boot| boot-jenkins),?(s+|$)
@@ -298,6 +441,17 @@ spec:
           - do-not-merge/work-in-progress
           - needs-ok-to-test
           - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test boot-vault
       trigger: (?m)^/test( all| boot| boot-vault),?(s+|$)
@@ -317,6 +471,17 @@ spec:
           - do-not-merge/work-in-progress
           - needs-ok-to-test
           - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test boot-lh
       trigger: (?m)^/test( all| boot| boot-lh| lighthouse),?(s+|$)
@@ -336,6 +501,17 @@ spec:
           - do-not-merge/work-in-progress
           - needs-ok-to-test
           - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test boot-lh-ghe
       trigger: (?m)^/test( all| boot| boot-lh-ghe| lighthouse),?(s+|$)
@@ -355,6 +531,17 @@ spec:
           - do-not-merge/work-in-progress
           - needs-ok-to-test
           - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test boot-lh-bs
       trigger: (?m)^/test( boot| boot-lh-bs| lighthouse),?(s+|$)
@@ -374,6 +561,17 @@ spec:
           - do-not-merge/work-in-progress
           - needs-ok-to-test
           - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test boot-lh-gl
       trigger: (?m)^/test( boot| boot-lh-gl| lighthouse),?(s+|$)
@@ -393,6 +591,17 @@ spec:
           - do-not-merge/work-in-progress
           - needs-ok-to-test
           - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
       report: true
       rerunCommand: /test devpods
       trigger: (?m)^/test( devpods),?(s+|$)


### PR DESCRIPTION
I'm tired of manually lgtm'ing every `jenkins-x-versions` PR. =) We're
still not at the point where we have consistent passing without need
to retry (particularly for `boot-vault` and `boot-local`, which I
haven't nailed down yet, and `boot-lh` and `boot-lh-ghe` due to the
sporadic `pipeline not found` error that we detect and transparently
retry for in Prow), but still, there's no point in requiring the
manual lgtm.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>