### PR TITLE
fix: Rename jx bdd context to static

### DIFF
--- a/env/templates/jx-scheduler.yaml
+++ b/env/templates/jx-scheduler.yaml
@@ -32,7 +32,7 @@ spec:
             entries:
             - integration
             - tekton
-            - bdd
+            - static
             - lint
             - boot-vault
       queries:
@@ -53,8 +53,8 @@ spec:
       trigger: (?m)^/test( all| integration),?(\s+|$)
     - agent: tekton
       alwaysRun: true
-      context: bdd
-      name: bdd
+      context: static
+      name: static
       queries:
         - labels:
             entries:
@@ -69,8 +69,8 @@ spec:
               - needs-rebase
               - needs-security-review
       report: true
-      rerunCommand: /test bdd
-      trigger: (?m)^/test( all| bdd),?(\s+|$)
+      rerunCommand: /test static
+      trigger: (?m)^/test( all| static| bdd),?(\s+|$)
     - agent: tekton
       alwaysRun: true
       context: tekton


### PR DESCRIPTION
It's a wee bit more accurate. =)

/hold

On hold until https://github.com/jenkins-x/jx/pull/5731 is merged

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>