### PR TITLE
fix: Bump e2e image

### DIFF
--- a/env/templates/e2e-gc-cj.yaml
+++ b/env/templates/e2e-gc-cj.yaml
@@ -30,7 +30,7 @@ spec:
               value: json
             - name: GKE_SA_KEY_FILE
               value: "/builder/home/bdd-credentials.json"
-            image: gcr.io/jenkinsxio/builder-go:0.1.754
+            image: gcr.io/jenkinsxio/builder-go:2.0.838-196
             imagePullPolicy: IfNotPresent
             name: e2e-gc
             resources: {}


### PR DESCRIPTION
This'll make it clean up SAs with the `-dn` suffix.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>