### PR TITLE
fix: Bump arcalos version update cronjob builder image

### DIFF
--- a/env/templates/arcalos-version-stream-update-cj.yaml
+++ b/env/templates/arcalos-version-stream-update-cj.yaml
@@ -39,7 +39,7 @@ spec:
               value: jenkins-x-bot
             - name: PIPELINE_KIND
               value: release
-            image: gcr.io/jenkinsxio/builder-go:0.1.754
+            image: gcr.io/jenkinsxio/builder-go::2.0.815-175
             imagePullPolicy: IfNotPresent
             name: arcalos-version-stream-update
             resources: {}


### PR DESCRIPTION
To match that used by the OSS version stream update cronjob