### PR TITLE
chore: Run bdd-jx postsubmits from `jenkins-x-release.yml`.

### DIFF
--- a/env/templates/bdd-jx-scheduler.yaml
+++ b/env/templates/bdd-jx-scheduler.yaml
@@ -1,0 +1,45 @@
+apiVersion: jenkins.io/v1
+kind: Scheduler
+metadata:
+  name: bdd-jx-scheduler
+spec:
+  plugins:
+    entries:
+      - label
+  postsubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      name: release
+      context: release
+  presubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      alwaysRun: true
+      context: pr-build
+      name: pr-build
+      policy:
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - pr-build
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      report: true
+      rerunCommand: /test this
+      trigger: (?m)^/test( all| this),?(\s+|$)

--- a/repositories/templates/bdd-jx-group.yaml
+++ b/repositories/templates/bdd-jx-group.yaml
@@ -1,0 +1,12 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepositoryGroup
+metadata:
+  name: bdd-jx-group
+spec:
+  scheduler:
+    apiVersion: jenkins.io/v1
+    kind: Scheduler
+    name: bdd-jx-scheduler
+  repositories: 
+  - name: jenkins-x-bdd-jx
+    kind: SourceRepository

--- a/repositories/templates/jenkins-x.yaml
+++ b/repositories/templates/jenkins-x.yaml
@@ -494,3 +494,19 @@ spec:
   providerName: github
   org: jenkins-x
   repo: jx-release-version
+---
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  labels:
+    owner: jenkins-x
+    provider: github
+    repository: bdd-jx
+  name: jenkins-x-bdd-jx
+  namespace: jx
+spec:
+  description: Imported application for jenkins-x/bdd-jx
+  provider: https://github.com
+  providerName: github
+  org: jenkins-x
+  repo: bdd-jx


### PR DESCRIPTION
I'm not sure how to get Prow to merge PRs without calling post-submits
afterwards, so for the moment, I decided to just copy what
`jenkins-x-boot-config` does and use a different context than the
default so we can have a no-op release in `bdd-jx/jenkins-x-release.yml`.

This will want to be merged before I add that to `bdd-jx`.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>