### PR TITLE
chore: Set a higher memory limit for jxui than the default

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
 - warrenbailey
 - cagiti
 - abayer
+- mpailloncy
 reviewers:
 - rawlingsj
 - jstrachan
@@ -18,3 +19,4 @@ reviewers:
 - warrenbailey
 - cagiti
 - abayer
+- mpailloncy

--- a/env/jx-app-ui/values.tmpl.yaml
+++ b/env/jx-app-ui/values.tmpl.yaml
@@ -1,0 +1,7 @@
+resources:
+  limits:
+    cpu: 200m
+    memory: 1Gi
+  requests:
+    cpu: 100m
+    memory: 256Mi


### PR DESCRIPTION
Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>