### PR TITLE
chore: Turning on debug logging in build controller

### DIFF
--- a/env/jenkins-x-platform/values.tmpl.yaml
+++ b/env/jenkins-x-platform/values.tmpl.yaml
@@ -151,6 +151,20 @@ controllerbuild:
   - "build"
   - "--batch-mode"
   - "--verbose"
+# Turning on debug logging until we resolve https://github.com/jenkins-x/jx/issues/6217
+  env:
+  - name: GIT_AUTHOR_EMAIL
+    value: jenkins-x@googlegroups.com
+  - name: GIT_AUTHOR_NAME
+    value: jenkins-x-bot
+  - name: JX_LOG_FORMAT
+    value: json
+  - name: JX_LOG_LEVEL
+    value: debug
+  - name: PIPELINE_KIND
+    value: dummy
+  - name: XDG_CONFIG_HOME
+    value: /home/jenkins
   role:
     enabled: true
     rules:


### PR DESCRIPTION
At least until we nail down
https://github.com/jenkins-x/jx/issues/6217 and https://github.com/jenkins-x/jx/issues/6246.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>