### PR TITLE
fix: quote boolean label value in namespace template

### DIFF
--- a/env/templates/000-namespace.yaml
+++ b/env/templates/000-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     env: dev
     team: jx
-    certmanager.k8s.io/disable-validation: true
+    certmanager.k8s.io/disable-validation: "true"
   name: jx
 spec:
   finalizers:


### PR DESCRIPTION
It never should have worked, and with kubectl 1.17, it errors rather than silently discarding invalid metadata values like this one.