### PR TITLE
fix: Proper naming of hugo-extended-docker

### DIFF
--- a/repositories/templates/jenkins-x.yaml
+++ b/repositories/templates/jenkins-x.yaml
@@ -214,7 +214,7 @@ metadata:
     owner: jenkins-x
     provider: github
     repository: hugo-extended-docker
-  name: jenkins-x-hugo
+  name: jenkins-x-hugo-extended-docker
   namespace: jx
 spec:
   description: Imported application for jenkins-x/hugo-extended-docker


### PR DESCRIPTION
Otherwise we get a dupe.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>