### PR TITLE
chore: Require BitBucket context on Lighthouse

### DIFF
--- a/env/templates/lh-scheduler.yaml
+++ b/env/templates/lh-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
             - github
             - ghe
             - gitlab
+            - bbs
       queries:
       - labels:
           entries:
@@ -120,7 +121,7 @@ spec:
       rerunCommand: /test github
       trigger: (?m)^/test( all| github),?(s+|$)
     - agent: tekton
-      alwaysRun: false
+      alwaysRun: true
       context: bbs
       name: bbs
       queries:


### PR DESCRIPTION
Our BitBucket Server instance is working again, so let's make this mandatory

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>