### PR TITLE
chore: Stop updating stable/nginx-ingress in version stream update cronjob

### DIFF
--- a/env/templates/version-stream-update-cj.yaml
+++ b/env/templates/version-stream-update-cj.yaml
@@ -25,6 +25,7 @@ spec:
             - --filter=*
             - --images
             - --excludes=jetstack/cert-manager
+            - --excludes=stable/nginx-ingress  # TODO: Remove once we know version stream TLS tests pass with nginx-ingres >=1.29.0
             - --batch-mode
             command:
             - jx


### PR DESCRIPTION
With `stable/nginx-ingress` 1.29.0 or 1.29.1 (the latest release as of
this time), ingresses aren't getting addresses. While this issue is
being investigated, we should stick with 1.28.3 for `stable/nginx-ingress`.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>