### PR TITLE
fix: Make jenkins-x-boot-config use rebase for PR merges

### DIFF
--- a/env/templates/boot-config-scheduler.yaml
+++ b/env/templates/boot-config-scheduler.yaml
@@ -3,6 +3,8 @@ kind: Scheduler
 metadata:
   name: boot-config-scheduler
 spec:
+  merger:
+    mergeMethod: rebase
   plugins:
     entries:
       - label


### PR DESCRIPTION
Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>