### PR TITLE
chore: Disable BBS context on Lighthouse due to BBS test instance issues

### DIFF
--- a/env/templates/lh-scheduler.yaml
+++ b/env/templates/lh-scheduler.yaml
@@ -30,7 +30,6 @@ spec:
             - github
             - ghe
             - gitlab
-            - bbs
       queries:
       - labels:
           entries:
@@ -121,7 +120,7 @@ spec:
       rerunCommand: /test github
       trigger: (?m)^/test( all| github),?(s+|$)
     - agent: tekton
-      alwaysRun: true
+      alwaysRun: false
       context: bbs
       name: bbs
       queries:


### PR DESCRIPTION
Looks like our license isn't valid or something, so...yeah. Let's
disable again.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>