### PR TITLE
chore: Update lighthouse values.tmpl.yaml from upstream

### DIFF
--- a/env/lighthouse/values.tmpl.yaml
+++ b/env/lighthouse/values.tmpl.yaml
@@ -14,7 +14,20 @@ git:
 service:
   name: hook
   
-replicaCount: 1
+replicaCount: 2
 
 image:
   repository: gcr.io/jenkinsxio/lighthouse
+
+vault:
+{{- if eq .Requirements.secretStorage "vault" }}
+  enabled: true
+{{- else }}
+  enabled: false
+{{- end }}
+
+clusterName: {{ .Requirements.cluster.clusterName }}
+
+user: "{{ .Parameters.pipelineUser.username }}"
+
+oauthToken: "{{ .Parameters.pipelineUser.token }}"

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -94,7 +94,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: gcr.io/jenkinsxio/builder-go:0.1.658
+          image: gcr.io/jenkinsxio/builder-go
         stages:
           - name: pr
             steps:


### PR DESCRIPTION
Part of preparing to switch tekton-weasel to use Lighthouse as its webhook engine.

Note that this isn't actually changing anything in the cluster, just making sure that when we do switch to Lighthouse, all we need to do is change `jx-requirements.yaml`'s `webhook` value.

Normally anyone switching from Prow to Lighthouse from an older boot config would need to do `jx upgrade boot` first to pick this up, but I wanna touch as little as possible here. =)

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>