### PR TITLE
chore: Update lighthouse values that'll work with ancient builder

### DIFF
--- a/env/lighthouse/values.tmpl.yaml
+++ b/env/lighthouse/values.tmpl.yaml
@@ -18,3 +18,9 @@ replicaCount: 1
 
 image:
   repository: gcr.io/jenkinsxio/lighthouse
+
+clusterName: {{ .Requirements.cluster.clusterName }}
+
+user: "{{ .Parameters.pipelineUser.username }}"
+
+oauthToken: "{{ .Parameters.pipelineUser.token }}"

--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -2,19 +2,24 @@ dependencies:
 - alias: tekton
   name: tekton
   repository: http://chartmuseum.jenkins-x.io
+  version: 0.0.48
 - alias: prow
   condition: prow.enabled
   name: prow
   repository: http://chartmuseum.jenkins-x.io
+  version: 0.0.1633
 - alias: lighthouse
   condition: lighthouse.enabled
   name: lighthouse
   repository: http://chartmuseum.jenkins-x.io
+  version: 0.0.423
 - name: jenkins-x-platform
   repository: http://chartmuseum.jenkins-x.io
+  version: 2.0.1942
 - condition: external-dns.enabled
   name: external-dns
   repository: https://charts.bitnami.com/bitnami
+  version: 2.16.0
 - name: jx-app-athens
   repository: http://chartmuseum.jenkins-x.io
   version: 0.0.17


### PR DESCRIPTION
Yeah, I dunno why the original didn't work with the jx in builder
0.1.658, leading to that whole rabbit hole stemming from updating the
builder, but I believe this one will work without needing to change
the builder.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>