### PR TITLE
chore: upgrade jx-sdm-app to 0.0.7

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -46,4 +46,4 @@ dependencies:
   version: 0.0.23
 - name: jx-sdm-app
   repository: http://chartmuseum.jenkins-x.io
-  version: 0.0.6
+  version: 0.0.7


### PR DESCRIPTION
This includes support for linking PRs to builds