### PR TITLE
chore: Keep PR builds for at least 5 days.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,6 +12,7 @@ approvers:
 - macox
 - daveconde
 - dgozalo
+- hferentschik
 reviewers:
 - rawlingsj
 - jstrachan
@@ -26,3 +27,4 @@ reviewers:
 - macox
 - daveconde
 - dgozalo
+- hferentschik

--- a/env/jenkins-x-platform/values.tmpl.yaml
+++ b/env/jenkins-x-platform/values.tmpl.yaml
@@ -202,6 +202,7 @@ gcactivities:
     - "activities"
     - "--batch-mode"
     - "--pr-history-limit=30"
+    - "--pull-request-age=120h"
   cronjob:
     enabled: true
     schedule: "0/30 * * * *"


### PR DESCRIPTION
It's too easy to lose track of older builds when we are removing all
PR `PipelineActivity`s after 48 hours. So let's bump that to 120 - if
there are performance problems due to the increase in CRDs retained (I
don't think there will be, but...), I'll improve `jx gc activity` to
be able to say "delete the `Pipeline` and friends after X duration,
but keep the `PipelineActivity` for Y duration".

Also add Hardy to OWNERS.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>