### PR TITLE
fix: Re-enable automatic updating of nginx-ingress chart for version stream

### DIFF
--- a/env/templates/version-stream-update-cj.yaml
+++ b/env/templates/version-stream-update-cj.yaml
@@ -25,7 +25,6 @@ spec:
             - --filter=*
             - --images
             - --excludes=jetstack/cert-manager
-            - --excludes=stable/nginx-ingress  # TODO: Remove once we know version stream TLS tests pass with nginx-ingres >=1.29.0
             - --batch-mode
             command:
             - jx


### PR DESCRIPTION
Version 1.31.0 of the nginx-ingress chart fixes it on k8s < 1.14, so
once https://github.com/jenkins-x/jenkins-x-versions/pull/826 passes,
we should re-enable automatically upgrading it again.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>