### PR TITLE
chore: switch arcalos to use alpha environment

### DIFF
--- a/env/templates/arcalos-config-configmap.yaml
+++ b/env/templates/arcalos-config-configmap.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: arcalos-config
 data:
-  aps_environment: poc
+  aps_environment: alpha


### PR DESCRIPTION
The alpha environment will now use alpha for PRs

Signed-off-by: Mark Cox <markcox20@hotmail.com>