### PR TITLE
chore: Switch to Lighthouse post-log link and retest fixes

### DIFF
--- a/env/jenkins-x-platform/values.tmpl.yaml
+++ b/env/jenkins-x-platform/values.tmpl.yaml
@@ -143,6 +143,7 @@ controllerbuild:
   - "--batch-mode"
   - "--git-credentials"
   - "--verbose"
+  - "--job-url-base=https://dashboard{{.Requirements.ingress.namespaceSubDomain}}{{.Requirements.ingress.domain}}"
   env:
     GIT_AUTHOR_EMAIL: jenkins-x@googlegroups.com
     GIT_AUTHOR_NAME: jenkins-x-bot

--- a/jx-requirements.yml
+++ b/jx-requirements.yml
@@ -37,4 +37,4 @@ storage:
 versionStream:
   ref: ""
   url: ""
-webhook: prow
+webhook: lighthouse


### PR DESCRIPTION
With https://github.com/jenkins-x/jx/issues/6791, https://github.com/jenkins-x/jx/issues/6792, https://github.com/jenkins-x/jx/issues/6794, and https://github.com/jenkins-x/jx/issues/6796 fixed since yesterday's attempt at switching weasel to Lighthouse, it's time for another attempt.

As with the previous attempt, the assumption is that issues will be found and we'll want to roll back to Prow. Which is fine!

This does differ from the previous attempt in that I've added the new `--job-url-base=...` argument to the build controller.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>