### PR TITLE
chore: Revert back to Prow again

### DIFF
--- a/jx-requirements.yml
+++ b/jx-requirements.yml
@@ -37,4 +37,4 @@ storage:
 versionStream:
   ref: ""
   url: ""
-webhook: lighthouse
+webhook: prow


### PR DESCRIPTION
We've got an old version stream here for some reason, and it's
resulting in stale images being used in the build controller and
lighthouse pods, meaning we don't actually pick up the fixes. So for
now, I'm going to just revert.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>