### PR TITLE
chore: Fix my mixup in requirements.yaml, turn on Lighthouse again

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -2,24 +2,19 @@ dependencies:
 - alias: tekton
   name: tekton
   repository: http://chartmuseum.jenkins-x.io
-  version: 0.0.48
 - alias: prow
   condition: prow.enabled
   name: prow
   repository: http://chartmuseum.jenkins-x.io
-  version: 0.0.1633
 - alias: lighthouse
   condition: lighthouse.enabled
   name: lighthouse
   repository: http://chartmuseum.jenkins-x.io
-  version: 0.0.423
 - name: jenkins-x-platform
   repository: http://chartmuseum.jenkins-x.io
-  version: 2.0.1942
 - condition: external-dns.enabled
   name: external-dns
   repository: https://charts.bitnami.com/bitnami
-  version: 2.16.0
 - name: jx-app-athens
   repository: http://chartmuseum.jenkins-x.io
   version: 0.0.17

--- a/jx-requirements.yml
+++ b/jx-requirements.yml
@@ -37,4 +37,4 @@ storage:
 versionStream:
   ref: ""
   url: ""
-webhook: prow
+webhook: lighthouse


### PR DESCRIPTION
I screwed up in https://github.com/jenkins-x/environment-tekton-weasel-dev/commit/57710fabed684a3897e568e6c063dd5e1112dc90 and commited something I shouldn't have. This will fix the reasons I reverted back to Prow just now.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>