### PR TITLE
chore: Bump Lighthouse replicaCount

### DIFF
--- a/env/lighthouse/values.tmpl.yaml
+++ b/env/lighthouse/values.tmpl.yaml
@@ -14,7 +14,7 @@ git:
 service:
   name: hook
   
-replicaCount: 1
+replicaCount: 2
 
 image:
   repository: gcr.io/jenkinsxio/lighthouse


### PR DESCRIPTION
Should have been 2 - that's what it is upstream, but yeah, stale boot config etc.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>