### PR TITLE
chore: Dogfood Lighthouse again, Feb 28

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,9 +9,11 @@ dependencies:
 - alias: lighthouse
   condition: lighthouse.enabled
   name: lighthouse
+  version: 0.0.459
   repository: http://chartmuseum.jenkins-x.io
 - name: jenkins-x-platform
   repository: http://chartmuseum.jenkins-x.io
+  version: 2.0.2027
 - condition: external-dns.enabled
   name: external-dns
   repository: https://charts.bitnami.com/bitnami

--- a/jx-requirements.yml
+++ b/jx-requirements.yml
@@ -37,4 +37,4 @@ storage:
 versionStream:
   ref: ""
   url: ""
-webhook: prow
+webhook: lighthouse


### PR DESCRIPTION
The version stream update barfed due to two PRs running `boot-vault-tls` in the same 30 minute window, but since everything else passed and the failure was entirely due to hostname collisions, I'm hardcoding in the `jenkins-x-platform` and `lighthouse` versions. The revert to Prow PR will remove those.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>