### PR TITLE
feat: add a whitesource postsubmit job to jx repository

### DIFF
--- a/env/templates/jx-scheduler.yaml
+++ b/env/templates/jx-scheduler.yaml
@@ -19,6 +19,23 @@ spec:
         - master
       name: release
       context: ""
+      policy:
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - whitesource
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      cluster: ""
+      context: whitesource
+      labels: {}
+      maxConcurrency: 0
+      name: whitesource
+      report: false
+      runIfChanged: ""
+      skipBranches: {}
   presubmits:
     replace: true
     entries:

--- a/env/templates/whitesource-secret.yaml
+++ b/env/templates/whitesource-secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.whitesource }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: whitesource
+  labels:
+    jenkins.io/created-by: jx
+type: Opaque
+data:
+  api-key: {{ .Values.whitesource.apiKey | b64enc }}
+  user-key: {{ .Values.whitesource.userKey | b64enc }}
+{{- end }}

--- a/env/values.tmpl.yaml
+++ b/env/values.tmpl.yaml
@@ -219,3 +219,7 @@ arcalos:
 CJXDChartmuseum:
   username: vault:tekton-weasel/creds/cb-cjxd-chartmuseum:username
   password: vault:tekton-weasel/creds/cb-cjxd-chartmuseum:password
+
+whitesource:
+  apiKey: vault:tekton-weasel/creds/whitesource:api-key
+  userKey: vault:tekton-weasel/creds//whitesource:user-key


### PR DESCRIPTION
Also add a secret which holds the whitesource agent credentials.

This will run the `jenkins-x-whitesrouce.yml` pipeline from jx repository
when a pull request is merged to master. This pipeline will scan all Go
dependencies and update them to whitesource service. See for more details: https://github.com/jenkins-x/jx/pull/6849