### PR TITLE
feat: enable the whitesource postsubmit job for lighthouse, bucketrepo, sso-operator

### DIFF
--- a/env/templates/lh-scheduler.yaml
+++ b/env/templates/lh-scheduler.yaml
@@ -15,6 +15,23 @@ spec:
         - master
       name: release
       context: ""
+      policy:
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - whitesource
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      cluster: ""
+      context: whitesource
+      labels: {}
+      maxConcurrency: 0
+      name: whitesource
+      report: false
+      runIfChanged: ""
+      skipBranches: {}
   presubmits:
     replace: true
     entries:

--- a/env/templates/whitesource-scheduler.yaml
+++ b/env/templates/whitesource-scheduler.yaml
@@ -1,0 +1,147 @@
+apiVersion: jenkins.io/v1
+kind: Scheduler
+metadata:
+  creationTimestamp: null
+  name: whitesource-scheduler
+spec:
+  approve:
+    issueRequired: false
+    lgtmActsAsApprove: true
+    requireSelfApproval: true
+  merger:
+    blockerLabel: ""
+    maxGoroutines: 0
+    mergeMethod: merge
+    policy:
+      fromBranchProtection: true
+      optionalContexts: {}
+      requiredContexts: {}
+      requiredIfPresentContexts: {}
+      skipUnknownContexts: false
+    prStatusBaseUrl: ""
+    squashLabel: ""
+    targetUrl: http://deck{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}
+  plugins:
+    entries:
+    - approve
+    - assign
+    - blunderbuss
+    - help
+    - hold
+    - lgtm
+    - lifecycle
+    - override
+    - size
+    - trigger
+    - wip
+    - heart
+    - cat
+    - dog
+    - pony
+    - override
+  policy:
+    protectTested: true
+  postsubmits:
+    entries:
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      cluster: ""
+      context: ""
+      labels: {}
+      maxConcurrency: 0
+      name: release
+      report: false
+      runIfChanged: ""
+      skipBranches: {}
+      policy:
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - whitesource
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      cluster: ""
+      context: whitesource
+      labels: {}
+      maxConcurrency: 0
+      name: whitesource
+      report: false
+      runIfChanged: ""
+      skipBranches: {}
+  presubmits:
+    entries:
+    - agent: tekton
+      alwaysRun: true
+      branches: {}
+      cluster: ""
+      context: pr-build
+      labels: {}
+      maxConcurrency: 0
+      mergeMethod: ""
+      name: pr-build
+      optional: false
+      policy:
+        Replace: false
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - pr-build
+      queries:
+      - excludedBranches: {}
+        includedBranches: {}
+        labels:
+          entries:
+          - approved
+        milestone: ""
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+        reviewApprovedRequired: false
+      - excludedBranches: {}
+        includedBranches: {}
+        labels:
+          entries:
+          - updatebot
+        milestone: ""
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+        reviewApprovedRequired: false
+      report: true
+      rerunCommand: /test this
+      runIfChanged: ""
+      skipBranches: {}
+      trigger: (?m)^/test( all| this),?(\s+|$)
+  schedulerAgent:
+    agent: tekton
+  trigger:
+    ignoreOkToTest: false
+    joinOrgUrl: ""
+    onlyOrgMembers: false
+    trustedOrg: {{ .Values.gitops.owner }}
+  welcome:
+  - message_template: Welcome
+  attachments:
+  - name: jobURLPrefix
+    urls:
+    - 'https://dashboard-jx.jenkins-x.live/teams'
+  - name: reportTemplate
+    urls:
+    - '{{`{{if eq .Spec.Type "presubmit"}}[View all Builds for this Pull Request](https://dashboard-jx.jenkins-x.live/teams/{{.Spec.Namespace}}/projects/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/PR-{{(index .Spec.Refs.Pulls 0).Number}}) {{else if eq .Spec.Type "batch"}} Run "jx get build log --owner {{.Spec.Refs.Org}} --repo {{.Spec.Refs.Repo}} --branch batch" whilst connected to the cluster. UI support coming soon. {{end}}`}}'
+  - name: jobURLTemplate
+    urls:
+    - '{{`{{if eq .Spec.Type "presubmit"}}https://dashboard-jx.jenkins-x.live/teams/{{.Spec.Namespace}}/projects/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/PR-{{(index .Spec.Refs.Pulls 0).Number}}/{{.Status.BuildID}}{{else if eq .Spec.Type "postsubmit"}}https://dashboard-jx.jenkins-x.live/teams/{{.Spec.Namespace}}/projects/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/{{.Spec.Refs.BaseRef}}/{{.Status.BuildID}}{{end}}`}}'

--- a/repositories/templates/whitesource-group.yaml
+++ b/repositories/templates/whitesource-group.yaml
@@ -1,0 +1,14 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepositoryGroup
+metadata:
+  name: whitesource-group
+spec:
+  scheduler:
+    apiVersion: jenkins.io/v1
+    kind: Scheduler
+    name: whitesource-scheduler
+  repositories: 
+  - name: jenkins-x-sso-operator
+    kind: SourceRepository
+  - name: jenkins-x-bucketrepo
+    kind: SourceRepository


### PR DESCRIPTION
Created a dedicated scheduler and a source repository group for sso-operator, bucketrepo
instead of modifying the default scheduler. This would have required to add the whitesource
pipeline file to all repositories that reference the default scheduler. Otherwise the meta-pipeline
creates a default pipeline which collides with the release pipeline from jenkins-x.yml file.

See the issue https://github.com/jenkins-x/jx/issues/6864 for more details.