### PR TITLE
feat: add more repositories to whitesource source repository group

### DIFF
--- a/repositories/templates/whitesource-group.yaml
+++ b/repositories/templates/whitesource-group.yaml
@@ -12,3 +12,13 @@ spec:
     kind: SourceRepository
   - name: jenkins-x-bucketrepo
     kind: SourceRepository
+  - name: cloudbees-jx-tenant-service
+    kind: SourceRepository
+  - name: cloudbees-lighthouse-githubapp
+    kind: SourceRepository
+  - name: cloudbees-jx-repository-controller
+    kind: SourceRepository
+  - name: cloudbees-jx-arcalos-role-controller
+    kind: SourceRepository
+  - name: cloudbees-jx-segment-controller
+    kind: SourceRepository


### PR DESCRIPTION
Add the following repositories: jx-tenant-service, lighthouse-githubapp,
jx-repository-controller, jx-arcalos-role-controller and jx-segment-controller