### PR TITLE
chore: Add GHE secret for an approver user

### DIFF
--- a/env/templates/git-test-ghe-approver-secret.yaml
+++ b/env/templates/git-test-ghe-approver-secret.yaml
@@ -1,0 +1,20 @@
+  
+{{- if .Values.JenkinsXGHEApproverTestUser }}
+apiVersion: v1
+data:
+  password: {{ .Values.JenkinsXGHEApproverTestUser.password | b64enc | quote }} # pragma: allowlist secret
+  username: {{ .Values.JenkinsXGHEApproverTestUser.username | b64enc | quote }}
+kind: Secret
+metadata:
+  name: jx-pipeline-git-github-ghe-approver
+  annotations:
+    jenkins.io/credentials-description: API Token for acccessing https://github.beescloud.com
+      Git service inside pipelines with a second user
+    jenkins.io/foo: bar
+    jenkins.io/name: GHE
+    jenkins.io/url: https://github.beescloud.com
+  labels:
+    jenkins.io/created-by: jx
+    jenkins.io/credentials-type: usernamePassword
+type: Opaque
+{{- end }}

--- a/env/values.tmpl.yaml
+++ b/env/values.tmpl.yaml
@@ -169,6 +169,10 @@ JenkinsXGHETestUser:
   username: vault:tekton-weasel/creds/jenkins-x-github-ent-test-user:username
   password: vault:tekton-weasel/creds/jenkins-x-github-ent-test-user:password # pragma: allowlist secret
 
+JenkinsXGHEApproverTestUser:
+  username: vault:tekton-weasel/creds/jenkins-x-github-ent-approver-test-user:username
+  password: vault:tekton-weasel/creds/jenkins-x-github-ent-approver-test-user:password # pragma: allowlist secret
+
 JenkinsXBBSTestUser:
   username: vault:tekton-weasel/creds/jenkins-x-bbs-test-user:username
   password: vault:tekton-weasel/creds/jenkins-x-bbs-test-user:password # pragma: allowlist secret


### PR DESCRIPTION
This is for use in Lighthouse BDD tests. The secret has been created in vault.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>