### PR TITLE
chore: Resurrect the lifecycle jobs

### DIFF
--- a/env/templates/jx-issue-lifecycle-close-cj.yaml
+++ b/env/templates/jx-issue-lifecycle-close-cj.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: jx-issue-lifecycle-close
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: jx-issue-lifecycle-close
+            release: jx
+        spec:
+          containers:
+          - image: gcr.io/k8s-prow/commenter:v20190528-0d7c4b53a
+            command:
+            - /app/robots/commenter/app.binary
+            args:
+            - |-
+              --query=org:jenkins-x
+              -label:lifecycle/frozen
+              label:lifecycle/rotten
+            - --updated=720h
+            - --token=/etc/token/oauth
+            - |-
+              --comment=Rotten issues close after 30d of inactivity.
+              Reopen the issue with `/reopen`.
+              Mark the issue as fresh with `/remove-lifecycle rotten`.
+              Provide feedback via https://jenkins-x.io/community.
+              /close
+            - --template
+            - --ceiling=10
+            - --confirm
+            imagePullPolicy: IfNotPresent
+            name: jx-issue-lifecycle-close
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - name: token
+              mountPath: /etc/token
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+          volumes:
+          - name: token
+            secret:
+              secretName: oauth-token
+  schedule: 5 * * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/env/templates/jx-issue-lifecycle-rotten-cj.yaml
+++ b/env/templates/jx-issue-lifecycle-rotten-cj.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: jx-issue-lifecycle-rotten
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: jx-issue-lifecycle-rotten
+            release: jx
+        spec:
+          containers:
+          - image: gcr.io/k8s-prow/commenter:v20190528-0d7c4b53a
+            command:
+            - /app/robots/commenter/app.binary
+            args:
+            - |-
+              --query=org:jenkins-x
+              -label:lifecycle/frozen
+              label:lifecycle/stale
+              -label:lifecycle/rotten
+            - --updated=720h
+            - --token=/etc/token/oauth
+            - |-
+              --comment=Stale issues rot after 30d of inactivity.
+              Mark the issue as fresh with `/remove-lifecycle rotten`.
+              Rotten issues close after an additional 30d of inactivity.
+              If this issue is safe to close now please do so with `/close`.
+              Provide feedback via https://jenkins-x.io/community.
+              /lifecycle rotten
+            - --template
+            - --ceiling=10
+            - --confirm
+            imagePullPolicy: IfNotPresent
+            name: jx-issue-lifecycle-rotten
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - name: token
+              mountPath: /etc/token
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+          volumes:
+          - name: token
+            secret:
+              secretName: oauth-token
+  schedule: 10 * * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/env/templates/jx-issue-lifecycle-stale-cj.yaml
+++ b/env/templates/jx-issue-lifecycle-stale-cj.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: jx-issue-lifecycle-stale
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: jx-issue-lifecycle-stale
+            release: jx
+        spec:
+          containers:
+          - image: gcr.io/k8s-prow/commenter:v20190528-0d7c4b53a
+            command:
+            - /app/robots/commenter/app.binary
+            args:
+            - |-
+              --query=org:jenkins-x
+              -label:lifecycle/frozen
+              -label:lifecycle/stale
+              -label:lifecycle/rotten
+            - --updated=2160h
+            - --token=/etc/token/oauth
+            - |-
+              --comment=Issues go stale after 90d of inactivity.
+              Mark the issue as fresh with `/remove-lifecycle stale`.
+              Stale issues rot after an additional 30d of inactivity and eventually close.
+              If this issue is safe to close now please do so with `/close`.
+              Provide feedback via https://jenkins-x.io/community.
+              /lifecycle stale
+            - --template
+            - --ceiling=30
+            - --confirm
+            imagePullPolicy: IfNotPresent
+            name: jx-issue-lifecycle-stale
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - name: token
+              mountPath: /etc/token
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+          volumes:
+          - name: token
+            secret:
+              secretName: oauth-token
+  schedule: 0 * * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false


### PR DESCRIPTION
These were run as periodics in pre-boot land - see
https://github.com/jenkins-x/prow-config-tekton/blob/master/prow/config.yaml#L2-L100. This
is my attempt to recreate them as cronjobs.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>