### PR TITLE
fix: Pin nginx-ingress chart to 1.34.2.

### DIFF
--- a/env/templates/arcalos-version-stream-update-cj.yaml
+++ b/env/templates/arcalos-version-stream-update-cj.yaml
@@ -28,6 +28,7 @@ spec:
             - --images
             - --excludes=jetstack/cert-manager
             - --excludes=jx-labs/jxl-boot
+            - --excludes=stable/nginx-ingress  # Stick with 1.34.2 due to https://github.com/helm/charts/pull/21654 breaking upgrades
             - --batch-mode
             - --verbose
             command:

--- a/env/templates/version-stream-update-cj.yaml
+++ b/env/templates/version-stream-update-cj.yaml
@@ -26,6 +26,7 @@ spec:
             - --images
             - --excludes=jetstack/cert-manager
             - --excludes=jx-labs/jxl-boot
+            - --excludes=stable/nginx-ingress  # Stick with 1.34.2 due to https://github.com/helm/charts/pull/21654 breaking upgrades
             - --batch-mode
             command:
             - jx


### PR DESCRIPTION
https://github.com/helm/charts/pull/21654 breaks upgrading deployments due to changes to the `PodDisruptionBudget` spec, which can't be changed apparently, resulting in this error in upgrades:

```
The PodDisruptionBudget "jxing-nginx-ingress-controller" is invalid: spec: Forbidden: updates to poddisruptionbudget spec are forbidden
```

So let's pin to 1.34.2 for the foreseeable future.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>