### PR TITLE
chore: Bump to jx-app-athens 0.0.18 for Go 1.13 support

### DIFF
--- a/env/jx-app-athens/templates/app.yaml
+++ b/env/jx-app-athens/templates/app.yaml
@@ -6,8 +6,8 @@ metadata:
     jenkins.io/chart-repository: http://chartmuseum.jenkins-x.io
   creationTimestamp: null
   labels:
-    chart: jx-app-athens-0.0.17
+    chart: jx-app-athens-0.0.18
     jenkins.io/app-name: jx-app-athens
-    jenkins.io/app-version: 0.0.17
+    jenkins.io/app-version: 0.0.18
   name: jx-app-athens-jx-app-athens
 spec: {}

--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
 - name: jx-app-athens
   repository: http://chartmuseum.jenkins-x.io
-  version: 0.0.17
+  version: 0.0.18
 - name: jx-app-sso
   repository: http://chartmuseum.jenkins-x.io
   version: 0.0.14


### PR DESCRIPTION
Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>