### PR TITLE
chore: Rollback to jx-app-athens 0.0.17

### DIFF
--- a/env/jx-app-athens/templates/app.yaml
+++ b/env/jx-app-athens/templates/app.yaml
@@ -6,8 +6,8 @@ metadata:
     jenkins.io/chart-repository: http://chartmuseum.jenkins-x.io
   creationTimestamp: null
   labels:
-    chart: jx-app-athens-0.0.18
+    chart: jx-app-athens-0.0.17
     jenkins.io/app-name: jx-app-athens
-    jenkins.io/app-version: 0.0.18
+    jenkins.io/app-version: 0.0.17
   name: jx-app-athens-jx-app-athens
 spec: {}

--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
 - name: jx-app-athens
   repository: http://chartmuseum.jenkins-x.io
-  version: 0.0.18
+  version: 0.0.17
 - name: jx-app-sso
   repository: http://chartmuseum.jenkins-x.io
   version: 0.0.14


### PR DESCRIPTION
Due to issues with a bad dependency failing to resolve with the newer Athens - https://github.com/jenkins-x/jx/pull/7031 fixes that but downstream builds will still fail for now, so let's be patient.
