### PR TITLE
fix: Lifecycle cronjobs don't query right with newlines in them

### DIFF
--- a/env/templates/jx-issue-lifecycle-close-cj.yaml
+++ b/env/templates/jx-issue-lifecycle-close-cj.yaml
@@ -21,10 +21,7 @@ spec:
             command:
             - /app/robots/commenter/app.binary
             args:
-            - |-
-              --query=org:jenkins-x
-              -label:lifecycle/frozen
-              label:lifecycle/rotten
+            - --query=org:jenkins-x -label:lifecycle/frozen label:lifecycle/rotten
             - --updated=720h
             - --token=/etc/token/oauth
             - |-

--- a/env/templates/jx-issue-lifecycle-rotten-cj.yaml
+++ b/env/templates/jx-issue-lifecycle-rotten-cj.yaml
@@ -21,11 +21,7 @@ spec:
             command:
             - /app/robots/commenter/app.binary
             args:
-            - |-
-              --query=org:jenkins-x
-              -label:lifecycle/frozen
-              label:lifecycle/stale
-              -label:lifecycle/rotten
+            - --query=org:jenkins-x -label:lifecycle/frozen label:lifecycle/stale -label:lifecycle/rotten
             - --updated=720h
             - --token=/etc/token/oauth
             - |-

--- a/env/templates/jx-issue-lifecycle-stale-cj.yaml
+++ b/env/templates/jx-issue-lifecycle-stale-cj.yaml
@@ -21,11 +21,7 @@ spec:
             command:
             - /app/robots/commenter/app.binary
             args:
-            - |-
-              --query=org:jenkins-x
-              -label:lifecycle/frozen
-              -label:lifecycle/stale
-              -label:lifecycle/rotten
+            - --query=org:jenkins-x -label:lifecycle/frozen -label:lifecycle/stale -label:lifecycle/rotten
             - --updated=2160h
             - --token=/etc/token/oauth
             - |-


### PR DESCRIPTION
This worked in Prow periodic jobs, but not in cronjobs. Fun! Here we need them all on one line. I did some experimenting and this seems to have done the trick.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>