### PR TITLE
chore: Remove obsolete plugins from scheduler config

### DIFF
--- a/env/templates/default-scheduler.yaml
+++ b/env/templates/default-scheduler.yaml
@@ -25,7 +25,6 @@ spec:
     entries:
     - approve
     - assign
-    - blunderbuss
     - help
     - hold
     - lgtm
@@ -34,7 +33,6 @@ spec:
     - size
     - trigger
     - wip
-    - heart
     - cat
     - dog
     - pony

--- a/env/templates/dev-env-scheduler.yaml
+++ b/env/templates/dev-env-scheduler.yaml
@@ -23,10 +23,8 @@ spec:
     targetUrl: http://deck{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}
   plugins:
     entries:
-    - config-updater
     - approve
     - assign
-    - blunderbuss
     - help
     - hold
     - lgtm
@@ -34,7 +32,6 @@ spec:
     - size
     - trigger
     - wip
-    - heart
     - cat
     - override
   policy:

--- a/env/templates/env-scheduler.yaml
+++ b/env/templates/env-scheduler.yaml
@@ -23,10 +23,8 @@ spec:
     targetUrl: http://deck{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}
   plugins:
     entries:
-    - config-updater
     - approve
     - assign
-    - blunderbuss
     - help
     - hold
     - lgtm
@@ -34,7 +32,6 @@ spec:
     - size
     - trigger
     - wip
-    - heart
     - cat
     - override
   policy:

--- a/env/templates/whitesource-scheduler.yaml
+++ b/env/templates/whitesource-scheduler.yaml
@@ -25,7 +25,6 @@ spec:
     entries:
     - approve
     - assign
-    - blunderbuss
     - help
     - hold
     - lgtm
@@ -34,7 +33,6 @@ spec:
     - size
     - trigger
     - wip
-    - heart
     - cat
     - dog
     - pony


### PR DESCRIPTION
None of `blunderbuss`, `heart`, or `config-updater` exist for
Lighthouse, and `config-updater` isn't actually relevant any more in
the first place, since we write to the configmaps via boot, not directly.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>