### PR TITLE
fix: Lifecycle cronjobs were using old Prow secret

### DIFF
--- a/env/templates/jx-issue-lifecycle-close-cj.yaml
+++ b/env/templates/jx-issue-lifecycle-close-cj.yaml
@@ -49,7 +49,7 @@ spec:
           volumes:
           - name: token
             secret:
-              secretName: oauth-token
+              secretName: lighthouse-oauth-token
   schedule: 5 * * * *
   successfulJobsHistoryLimit: 3
   suspend: false

--- a/env/templates/jx-issue-lifecycle-rotten-cj.yaml
+++ b/env/templates/jx-issue-lifecycle-rotten-cj.yaml
@@ -50,7 +50,7 @@ spec:
           volumes:
           - name: token
             secret:
-              secretName: oauth-token
+              secretName: lighthouse-oauth-token
   schedule: 10 * * * *
   successfulJobsHistoryLimit: 3
   suspend: false

--- a/env/templates/jx-issue-lifecycle-stale-cj.yaml
+++ b/env/templates/jx-issue-lifecycle-stale-cj.yaml
@@ -50,7 +50,7 @@ spec:
           volumes:
           - name: token
             secret:
-              secretName: oauth-token
+              secretName: lighthouse-oauth-token
   schedule: 0 * * * *
   successfulJobsHistoryLimit: 3
   suspend: false


### PR DESCRIPTION
They should be using the Lighthouse one now instead.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>