### PR TITLE
fix: Set JX_HOME on e2e cronjob

### DIFF
--- a/env/templates/e2e-gc-cj.yaml
+++ b/env/templates/e2e-gc-cj.yaml
@@ -30,6 +30,8 @@ spec:
               value: json
             - name: GKE_SA_KEY_FILE
               value: "/builder/home/bdd-credentials.json"
+            - name: JX_HOME
+              value: /home/jenkins/.jx
             image: gcr.io/jenkinsxio/builder-go:{{ .Values.versions.builders }}
             imagePullPolicy: IfNotPresent
             name: e2e-gc


### PR DESCRIPTION
@daveconde's recent change to the builders breaks `jx step e2e gc ...`
when `JX_HOME` isn't set, so let's work around that for now.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>