### PR TITLE
fix: Add legacy hmac-token secret

### DIFF
--- a/env/templates/hmacsecret.yaml
+++ b/env/templates/hmacsecret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hmac-token
+type: Opaque
+data:  
+  hmac: {{ default "" .Values.legacyHMACToken | b64enc | quote }}

--- a/env/values.tmpl.yaml
+++ b/env/values.tmpl.yaml
@@ -244,3 +244,5 @@ AWSCreds:
   credentials: vault:tekton-weasel/creds/aws_creds:credentials
   account_id: vault:tekton-weasel/creds/aws_creds:account_id
   vault_user: vault:tekton-weasel/creds/aws_creds:vault_user
+
+legacyHMACToken: "{{ .Parameters.prow.hmacToken }}"


### PR DESCRIPTION
Because we're on such an old jx version in the dev env pipeline that
it doesn't know what to do with `lighthouse-hmac-token`.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>