### PR TITLE
chore: Temporarily pinning e2e gc job to older jx image

### DIFF
--- a/env/templates/e2e-gc-cj.yaml
+++ b/env/templates/e2e-gc-cj.yaml
@@ -30,7 +30,7 @@ spec:
               value: json
             - name: GKE_SA_KEY_FILE
               value: "/builder/home/bdd-credentials.json"
-            image: gcr.io/jenkinsxio/builder-go:{{ .Values.versions.builders }}
+            image: gcr.io/jenkinsxio/builder-go:2.1.20-646
             imagePullPolicy: IfNotPresent
             name: e2e-gc
             resources: {}


### PR DESCRIPTION
Because otherwise it fails when executing the generated bash script
with gcloud not being on the path.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>