### PR TITLE
chore: Make BitBucket Server context required for Lighthouse PRs

### DIFF
--- a/env/templates/lh-scheduler.yaml
+++ b/env/templates/lh-scheduler.yaml
@@ -47,6 +47,7 @@ spec:
             - github
             - ghe
             - gitlab
+            - bbs
       queries:
       - labels:
           entries:
@@ -137,7 +138,7 @@ spec:
       rerunCommand: /test github
       trigger: (?m)^/test( all| bdd| all-gh| github),?(s+|$)
     - agent: tekton
-      alwaysRun: false
+      alwaysRun: true
       context: bbs
       name: bbs
       queries:


### PR DESCRIPTION
To be merged once we've actually merged the BBS support.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>