### PR TITLE
fix: Turn off gh-pages reporting in build controller

### DIFF
--- a/env/jenkins-x-platform/values.tmpl.yaml
+++ b/env/jenkins-x-platform/values.tmpl.yaml
@@ -139,9 +139,7 @@ controllerbuild:
   args:
   - "controller"
   - "build"
-  - "--git-reporting"
   - "--batch-mode"
-  - "--git-credentials"
   - "--verbose"
   - "--job-url-base=https://dashboard{{.Requirements.ingress.namespaceSubDomain}}{{.Requirements.ingress.domain}}"
   env:


### PR DESCRIPTION
Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>