### PR TITLE
chore: Add cronjob syncing quay.io nginx ingress images to gcr.io

### DIFF
--- a/env/templates/sync-nginx-images-cj.yaml
+++ b/env/templates/sync-nginx-images-cj.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: sync-nginx-images-to-gcr
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: sync-nginx-images
+            release: jx
+        spec:
+          containers:
+          - command: ["./sync-nginx-images.sh"]
+            image: quay.io/skopeo/upstream
+            imagePullPolicy: IfNotPresent
+            name: sync-images
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - name: kaniko-secret
+              mountPath: /kaniko-secrets
+            - name: sync-nginx-images-script
+              mountPath: /sync-nginx-images.sh
+              subPath: sync-nginx-images.sh
+          volumes:
+          - name: kaniko-secret
+            secret:
+              secretName: kaniko-secret
+              items:
+              - key: kaniko-secret
+                path: kaniko/kaniko-secret.json
+          - name: sync-nginx-images-script
+            configMap:
+              name: sync-nginx-images-script
+              defaultMode: 0777
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+  schedule: 0 */12 * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/env/templates/sync-nginx-images-script-cm.yaml
+++ b/env/templates/sync-nginx-images-script-cm.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sync-nginx-images-script
+data:
+  sync-nginx-images.sh: |
+    #!/bin/sh
+    cat /kaniko-secrets/kaniko/kaniko-secret.json | /bin/skopeo login -u _json_key --password-stdin https://gcr.io
+    /bin/skopeo sync --src docker --dest docker quay.io/kubernetes-ingress-controller/nginx-ingress-controller gcr.io/jenkinsxio


### PR DESCRIPTION
So that we don't have to depend on quay.io being up all the time,
given that it's often not.

Part of https://github.com/jenkins-x/jx/issues/7256

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>