### PR TITLE
chore: Add new lighthouse-config library repository

### DIFF
--- a/repositories/templates/jenkins-x.yaml
+++ b/repositories/templates/jenkins-x.yaml
@@ -622,3 +622,19 @@ spec:
   providerName: github
   org: jenkins-x
   repo: logrus-stackdriver-formatter
+---
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  labels:
+    owner: jenkins-x
+    provider: github
+    repository: lighthouse-config
+  name: jenkins-x-lighthouse-config
+  namespace: jx
+spec:
+  description: Imported application for jenkins-x/lighthouse-config
+  provider: https://github.com
+  providerName: github
+  org: jenkins-x
+  repo: lighthouse-config


### PR DESCRIPTION
https://github.com/jenkins-x/lighthouse-config - I'm going to be switching jx and lighthouse to depend on this rather than jx depending on Prow and Lighthouse having its own copy.

This will allow us to start adding things to the config without needing a circular dependency (Lighthouse already depends on jx, so we don't want jx to depend on Lighthouse!).

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>