### PR TITLE
fix: Use v1.0.489 tag in version stream

### DIFF
--- a/jx-requirements.yml
+++ b/jx-requirements.yml
@@ -35,6 +35,6 @@ storage:
     enabled: false
     url: ""
 versionStream:
-  ref: ""
-  url: ""
+  ref: v1.0.489
+  url: https://github.com/jenkins-x/jenkins-x-versions.git
 webhook: lighthouse


### PR DESCRIPTION
This is the last release of the version stream before https://github.com/jenkins-x/jx/releases/tag/v2.1.56, the jx release with the external vault changes that we believe are causing problems with prod builds.

We'll be building a new prod cluster/env next week so that we can actually use `jx upgrade boot` properly from then on.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>