### PR TITLE
chore: Disable cronjobs moving to oss-weasel

### DIFF
--- a/env/templates/arcalos-cleanup-cj.yaml
+++ b/env/templates/arcalos-cleanup-cj.yaml
@@ -77,4 +77,4 @@ spec:
           serviceAccountName: tekton-bot
   schedule: 0 * * * *
   successfulJobsHistoryLimit: 3
-  suspend: false
+  suspend: true

--- a/env/templates/arcalos-version-stream-update-cj.yaml
+++ b/env/templates/arcalos-version-stream-update-cj.yaml
@@ -56,4 +56,4 @@ spec:
           serviceAccountName: tekton-bot
   schedule: 0 */12 * * *
   successfulJobsHistoryLimit: 3
-  suspend: false
+  suspend: true

--- a/env/templates/e2e-gc-cj.yaml
+++ b/env/templates/e2e-gc-cj.yaml
@@ -51,4 +51,4 @@ spec:
           terminationGracePeriodSeconds: 30
   schedule: 0/10 * * * *
   successfulJobsHistoryLimit: 3
-  suspend: false
+  suspend: true

--- a/env/templates/jx-issue-lifecycle-close-cj.yaml
+++ b/env/templates/jx-issue-lifecycle-close-cj.yaml
@@ -52,4 +52,4 @@ spec:
               secretName: lighthouse-oauth-token
   schedule: 5 * * * *
   successfulJobsHistoryLimit: 3
-  suspend: false
+  suspend: true

--- a/env/templates/jx-issue-lifecycle-rotten-cj.yaml
+++ b/env/templates/jx-issue-lifecycle-rotten-cj.yaml
@@ -53,4 +53,4 @@ spec:
               secretName: lighthouse-oauth-token
   schedule: 10 * * * *
   successfulJobsHistoryLimit: 3
-  suspend: false
+  suspend: true

--- a/env/templates/jx-issue-lifecycle-stale-cj.yaml
+++ b/env/templates/jx-issue-lifecycle-stale-cj.yaml
@@ -53,4 +53,4 @@ spec:
               secretName: lighthouse-oauth-token
   schedule: 0 * * * *
   successfulJobsHistoryLimit: 3
-  suspend: false
+  suspend: true

--- a/env/templates/sync-nginx-images-cj.yaml
+++ b/env/templates/sync-nginx-images-cj.yaml
@@ -48,4 +48,4 @@ spec:
           terminationGracePeriodSeconds: 30
   schedule: 0 */12 * * *
   successfulJobsHistoryLimit: 3
-  suspend: false
+  suspend: true

--- a/env/templates/version-stream-update-cj.yaml
+++ b/env/templates/version-stream-update-cj.yaml
@@ -53,4 +53,4 @@ spec:
           serviceAccountName: tekton-bot
   schedule: 0 */12 * * *
   successfulJobsHistoryLimit: 3
-  suspend: false
+  suspend: true


### PR DESCRIPTION
Everything but `copy-charts-index` is moving now, that'll follow when we actually move builds over etc.

See https://github.com/jenkins-x/environment-oss-weasel-dev/pull/4 for the new cronjobs.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>