### PR TITLE
chore: Move jenkins-x/lighthouse repository to oss-weasel

### DIFF
--- a/repositories/templates/lh-group.yaml
+++ b/repositories/templates/lh-group.yaml
@@ -7,6 +7,6 @@ spec:
     apiVersion: jenkins.io/v1
     kind: Scheduler
     name: lh-scheduler
-  repositories: 
+  repositories:
   - name: jenkins-x-lighthouse
     kind: SourceRepository


### PR DESCRIPTION
Doing a trial run of an individual project first.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>