### PR TITLE
chore: Disable the copy-chart-index cronjob

### DIFF
--- a/env/templates/copy-charts-index-cj.yaml
+++ b/env/templates/copy-charts-index-cj.yaml
@@ -53,4 +53,4 @@ spec:
               secretName: gcs-jenkinsx-chartmuseum
   schedule: '*/2 * * * *'
   successfulJobsHistoryLimit: 3
-  suspend: false
+  suspend: true


### PR DESCRIPTION
It works on oss-weasel now, so...

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>